### PR TITLE
Add specific bug reporting guidelines to contributing.md [ci skip]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,16 +1,34 @@
-Ruby on Rails is a volunteer effort. We encourage you to pitch in. [Join the team](http://contributors.rubyonrails.org)!
+Ruby on Rails is a volunteer effort. We encourage you to pitch in and [join the team](http://contributors.rubyonrails.org)!
 
-* If you want to submit a bug report please make sure to follow our [reporting guidelines](http://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#reporting-an-issue).
+* To **submit a patch**, please read the [Contributing to Ruby on Rails](http://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html) guide.
 
-* If you want to submit a patch, please read the [Contributing to Ruby on Rails](http://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html) guide.
+* To **contribute to Rails documentation**, please read the [Contributing to the Rails Documentation](http://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation) section of the aforementioned guide.
 
-* If you want to contribute to Rails documentation, please read the [Contributing to the Rails Documentation](http://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation) section of the aforementioned guide.
+* To ask a question about **how to use Ruby on Rails**, please [ask it on the rubyonrails-talk mailing list](https://groups.google.com/forum/?fromgroups#!forum/rubyonrails-talk).
 
-*We only accept bug reports and pull requests on GitHub*.
+* To suggest a **change or new feature**, please [suggest it on the rubyonrails-core mailing list](https://groups.google.com/forum/?fromgroups#!forum/rubyonrails-core) and start writing code.
 
-* If you have a question about how to use Ruby on Rails, please [ask it on the rubyonrails-talk mailing list](https://groups.google.com/forum/?fromgroups#!forum/rubyonrails-talk).
+**_We only accept bug reports and pull requests on GitHub._** _To submit a bug report, please **follow these steps:**_
 
-* If you have a change or new feature in mind, please [suggest it on the rubyonrails-core mailing list](https://groups.google.com/forum/?fromgroups#!forum/rubyonrails-core) and start writing code.
+* **Ensure the bug was not already reported** by searching on GitHub under [Issues](https://github.com/rails/rails/issues).
+
+* If unable to find an open issue addressing the problem, **[open a new one](https://github.com/rails/rails/issues/new)**.
+
+* The issue report should include:
+  * A **title and clear description**
+  * As much relevant information as possible and a **code sample demonstrating the issue**
+  * An **executable test case** demonstrating the expected behavior that is not occurring
+
+* Use the relevant bug report templates to compose the issue (latest release / edge):
+  * **Template for Active Record** (models, database) issues: [gem](https://github.com/rails/rails/blob/master/guides/bug_report_templates/active_record_gem.rb) / [master](https://github.com/rails/rails/blob/master/guides/bug_report_templates/active_record_master.rb)
+  * **Template for Action Pack** (controllers, routing) issues: [gem](https://github.com/rails/rails/blob/master/guides/bug_report_templates/action_controller_gem.rb) / [master](https://github.com/rails/rails/blob/master/guides/bug_report_templates/action_controller_master.rb)
+  * **Generic template** for other issues: [gem](https://github.com/rails/rails/blob/master/guides/bug_report_templates/generic_gem.rb) / [master](https://github.com/rails/rails/blob/master/guides/bug_report_templates/generic_master.rb)
+
+* Simply copy the content of the appropriate template into a .rb file, make the necessary changes to demonstrate the issue, and **paste the content into the issue description**.
+
+* That's it! Sumbit the issue.
+
+* For more detailed information on submitting a bug report and creating an issue, visit our [reporting guidelines](http://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#reporting-an-issue).
 
 Thanks! :heart: :heart: :heart:
 


### PR DESCRIPTION
## Problem
- Many new contributors are unaware of the bug reporting guidelines, specifically, the existence of the prepared bug report templates. These templates make it much easier for Rails team members to understand and quickly respond to issues, so it is highly preferable that they are used.
- The link provided above issues and PRs ("Please review the guidelines for contributing to this repository.") takes you to contributing.md which is simply a series of links which in turn require more clicks to truly understand the preferred pattern of opening an issue.
- @sgrif mentioned in a [Bikeshed](bikeshed.fm) episode that it would be a good idea to move some reporting guidelines into contributing.md given these points.
## Solution
- Port some of the key points from [reporting guidelines](http://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#reporting-an-issue) directly into contributing.md so contributors need not look much further for how to properly create an issue.
- Now we have an abridged version of reporting guidelines right in contributing.md.

Also:
- Add boldface and bullets to make the language more readable.
- Make sentences declarative.
- Remove "you"s.

Before:
![image](https://cloud.githubusercontent.com/assets/4148745/11508777/7d2d39ce-9828-11e5-9f17-ffa81e37838d.png)

After:
![image](https://cloud.githubusercontent.com/assets/4148745/11508815/afe69414-9828-11e5-9a5e-36232763f900.png)
